### PR TITLE
Add more units for villagers-required/compare units

### DIFF
--- a/public/data.json
+++ b/public/data.json
@@ -1036,8 +1036,61 @@
             "trainTime": 24
         },
         
+        {
+            "name": "plumed archer",
+            "ageReq": 3,
+            "mAtk": 0,
+            "pAtk": 5,
+            "mDef": 0,
+            "pDef": 1,
+            "hp": 50,
+            "speed": 1.2,
+            "lineOfSight": 6,
+            "rateOfFire": 1.9,
+            "projSpeed": 7.0,
+            "accuracy": 0.80,
+            "range": 4,
+            "frameDelay": 5,
+            "cost":{
+                "wood": 55,
+                "gold": 55
+            },
+            "armorClasses": [[15, 0], [19, 0]],
+            "bonus":[[27, 2], [1, 1], [32, 1]],
+            "damageTechs":["elite plumed archer", "archerDefense", "archerAttack", "chemistry"],
+            "otherTechs":["ballistics", "thumb ring","faith", "heresy", "conscription"],
+            "uniqueDamageTechs":[],
+            "uniqueOtherTechs":[],
+            "trainTime": 16
+        },
         
-        
+        {
+            "name": "chu ko nu",
+            "ageReq": 3,
+            "mAtk": 0,
+            "pAtk": 8,
+            "mDef": 0,
+            "pDef": 0,
+            "hp": 45,
+            "speed": 0.96,
+            "lineOfSight": 6,
+            "rateOfFire": 3.0,
+            "projSpeed": 7,
+            "accuracy": 0.85,
+            "range": 4,
+            "frameDelay": 3,
+            "cost":{
+                "wood": 40,
+                "gold": 35
+            },
+            "armorClasses": [[15, 0], [19, 0]],
+            "bonus":[[27, 2]],
+            "damageTechs":["elite chu ko nu", "archerDefense", "archerAttack", "chemistry", "rocketry"],
+            "otherTechs":["ballistics", "thumb ring","faith", "heresy", "conscription"],
+            "uniqueDamageTechs":[],
+            "uniqueOtherTechs":[],
+            "trainTime": 16
+        },
         
         {
             "name": "house",
@@ -1373,6 +1426,12 @@
         ],
         [
             "skirmisher", "elite skirmisher", "imperial skirmisher"
+        ],
+        [
+            "chu ko nu", "elite chu ko nu"
+        ],
+        [
+            "plumed archer", "elite plumed archer"
         ],
         [
             "cavalry archer", "heavy cavalry archer"
@@ -2849,7 +2908,35 @@
             "time": 60
         },
         
-        
+        {
+            "name": "elite plumed archer",
+            "ageReq": 4,
+            "cost": {
+                "wood": 1000,
+                "food": 700
+            },
+            "effects":{
+                "hp": 15,
+                "bonus":[[1, 1], [32, 1]],
+                "accuracy": 0.10,
+                "pDef": 2,
+                "range": 1
+            },
+            "time": 45
+        },
+
+        {
+            "name": "elite chu ko nu",
+            "ageReq": 4,
+            "cost": {
+                "food": 760,
+                "wood": 760
+            },
+            "effects":{
+                "hp": 5
+            },
+            "time": 50
+        },
         
         {
             "name": "sappers",

--- a/public/data.json
+++ b/public/data.json
@@ -1036,8 +1036,61 @@
             "trainTime": 24
         },
         
+        {
+            "name": "plumed archer",
+            "ageReq": 3,
+            "mAtk": 0,
+            "pAtk": 5,
+            "mDef": 0,
+            "pDef": 1,
+            "hp": 50,
+            "speed": 1.2,
+            "lineOfSight": 6,
+            "rateOfFire": 1.9,
+            "projSpeed": 7.0,
+            "accuracy": 0.80,
+            "range": 4,
+            "frameDelay": 5,
+            "cost":{
+                "wood": 55,
+                "gold": 55
+            },
+            "armorClasses": [[15, 0], [19, 0]],
+            "bonus":[[27, 2], [1, 1], [32, 1]],
+            "damageTechs":["elite plumed archer", "archerDefense", "archerAttack"],
+            "otherTechs":["ballistics", "thumb ring","faith", "heresy", "conscription"],
+            "uniqueDamageTechs":[],
+            "uniqueOtherTechs":[],
+            "trainTime": 16
+        },
         
-        
+        {
+            "name": "chu ko nu",
+            "ageReq": 3,
+            "mAtk": 0,
+            "pAtk": 8,
+            "mDef": 0,
+            "pDef": 0,
+            "hp": 45,
+            "speed": 0.96,
+            "lineOfSight": 6,
+            "rateOfFire": 3.0,
+            "projSpeed": 7,
+            "accuracy": 0.85,
+            "range": 4,
+            "frameDelay": 3,
+            "cost":{
+                "wood": 40,
+                "gold": 35
+            },
+            "armorClasses": [[15, 0], [19, 0]],
+            "bonus":[[27, 2]],
+            "damageTechs":["elite chu ko nu", "archerDefense", "archerAttack", "rocketry"],
+            "otherTechs":["ballistics", "thumb ring","faith", "heresy", "conscription"],
+            "uniqueDamageTechs":[],
+            "uniqueOtherTechs":[],
+            "trainTime": 16
+        },
         
         {
             "name": "house",
@@ -1373,6 +1426,12 @@
         ],
         [
             "skirmisher", "elite skirmisher", "imperial skirmisher"
+        ],
+        [
+            "chu ko nu", "elite chu ko nu"
+        ],
+        [
+            "plumed archer", "elite plumed archer"
         ],
         [
             "cavalry archer", "heavy cavalry archer"
@@ -2849,7 +2908,35 @@
             "time": 60
         },
         
-        
+        {
+            "name": "elite plumed archer",
+            "ageReq": 4,
+            "cost": {
+                "wood": 1000,
+                "food": 700
+            },
+            "effects":{
+                "hp": 15,
+                "bonus":[[1, 1], [32, 1]],
+                "accuracy": 0.10,
+                "pDef": 2,
+                "range": 1
+            },
+            "time": 45
+        },
+
+        {
+            "name": "elite chu ko nu",
+            "ageReq": 4,
+            "cost": {
+                "food": 760,
+                "wood": 760
+            },
+            "effects":{
+                "hp": 5
+            },
+            "time": 50
+        },
         
         {
             "name": "sappers",

--- a/public/villagers-required.js
+++ b/public/villagers-required.js
@@ -169,7 +169,9 @@ $(function(){
             "watch tower":"<p>The numbers for constantly building watch towers are a bit high since there's always some downtime for when your villagers go to the next building location. You will also need stone for repairs, so the numbers on stone are just a guideline. 5 stone miners is probably the maximum you'll need in an actual game for tower rushing.</p>",
             "cataphract":"<p></p>",
             "jaguar warrior":"<p>The train time for jaguar warriors is 20, but it is always reduced to 17 by the Aztec's civ bonus.</p>",
-            "karambit warrior":"<p></p>"
+            "karambit warrior":"<p></p>",
+            "plumed archer":"<p>Select appropriate age (Castle or Imperial) to determine the cost of the unit.</p>"
+                            
             
         };
         let unitVariety = {
@@ -190,10 +192,6 @@ $(function(){
                     "Indians - Imperial Age":{
                         "cost": {"food": 0.25},
                         "costPercent": true
-                    },
-                    "Persians - Dark Age":{
-                        "trainTime": 1.05,
-                        "trainTimePercent": true
                     },
                     "Persians - Feudal Age":{
                         "trainTime": 1.10,
@@ -663,10 +661,6 @@ $(function(){
                     "Italians Civ Bonus":{
                         "cost": {"wood": -15}
                     },
-                    "Persians - Dark Age":{
-                        "trainTime": 1.05,
-                        "trainTimePercent": true
-                    },
                     "Persians - Feudal Age":{
                         "trainTime": 1.1,
                         "trainTimePercent": true
@@ -702,10 +696,6 @@ $(function(){
                     "Portuguese Civ Bonus":{
                         "cost": {"gold": 0.15},
                         "costPercent": true
-                    },
-                    "Persians - Dark Age":{
-                        "trainTime": 1.05,
-                        "trainTimePercent": true
                     },
                     "Persians - Feudal Age":{
                         "trainTime": 1.1,
@@ -746,10 +736,6 @@ $(function(){
                     "Portuguese Civ Bonus":{
                         "cost": {"gold": 0.15},
                         "costPercent": true
-                    },
-                    "Persians - Dark Age":{
-                        "trainTime": 1.05,
-                        "trainTimePercent": true
                     },
                     "Persians - Feudal Age":{
                         "trainTime": 1.1,
@@ -794,10 +780,6 @@ $(function(){
                     "Portuguese Civ Bonus":{
                         "cost": {"gold": 0.15},
                         "costPercent": true
-                    },
-                    "Persians - Dark Age":{
-                        "trainTime": 1.05,
-                        "trainTimePercent": true
                     },
                     "Persians - Feudal Age":{
                         "trainTime": 1.1,
@@ -850,10 +832,6 @@ $(function(){
                     "Vikings Civ Bonus":{
                         "cost": {"wood": 0.2, "gold": 0.2},
                         "costPercent": true
-                    },
-                    "Persians - Dark Age":{
-                        "trainTime": 1.05,
-                        "trainTimePercent": true
                     },
                     "Persians - Feudal Age":{
                         "trainTime": 1.1,
@@ -1043,6 +1021,50 @@ $(function(){
                         "trainTime": 1.25,
                         "trainTimePercent": true
                     }
+                }
+            },
+            "chu ko nu": {
+                "civs":{
+                    
+                },
+                "upgrades": {
+                    
+                    "Conscription":{
+                        "trainTime": 1.33,
+                        "trainTimePercent": true
+                    },
+                    "Kasbah":{
+                        "trainTime": 1.25,
+                        "trainTimePercent": true
+                    },
+                    "Turks Team Bonus":{
+                        "trainTime": 1.25,
+                        "trainTimePercent": true
+                    }
+                }
+            },
+
+            "plumed archer": {
+                "civs":{
+                    "Mayans - Castle Age":{
+                        "cost": {"wood": 0.19, "gold": 0.19},
+                        "costPercent": true
+                    },
+                    "Mayans - Imperial Age":{
+                        "cost": {"wood": 0.29, "gold": 0.29},
+                        "costPercent": true
+                    }
+                },
+                "upgrades": {
+                    
+                    "Conscription":{
+                        "trainTime": 1.33,
+                        "trainTimePercent": true
+                    },
+                    "Kasbah":{
+                        "trainTime": 1.25,
+                        "trainTimePercent": true
+                    },
                 }
             }
         };
@@ -1301,7 +1323,7 @@ $(function(){
         }
         
         //Which units to show and in what order.
-        let unitsShown = ["villager", "militia", "spearman", "eagle scout", "archer", "skirmisher", "cavalry archer", "hand cannoneer", "scout cavalry", "knight", "camel rider", "battle elephant", "monk", "battering ram", "mangonel", "scorpion", "bombard cannon", "fishing ship", "fire galley", "galley", "demolition raft", "cannon galleon" ,"house", "farm", "watch tower", "cataphract", "jaguar warrior", "karambit warrior", "conquistador"];
+        let unitsShown = ["villager", "militia", "spearman", "eagle scout", "archer", "skirmisher", "cavalry archer", "hand cannoneer", "scout cavalry", "steppe lancer", "knight", "camel rider", "battle elephant", "monk", "battering ram", "mangonel", "scorpion", "bombard cannon", "fishing ship", "fire galley", "galley", "demolition raft", "cannon galleon" ,"house", "farm", "watch tower", "cataphract", "jaguar warrior", "karambit warrior", "conquistador", "chu ko nu", "plumed archer"];
         for(let i = 0; i < unitsShown.length; i++){
             let unitImg = $("<div class='unit-show-img showing-img' unit='"+unitsShown[i]+"' title='"+unitsShown[i]+"'></div>");
             let img = $("<img src='img/"+unitsShown[i]+".png'>");


### PR DESCRIPTION
- Added steppe lancer to villagers-required.js, data.json was already populated.
- Added chu ko nu to data.json
- Added plumed archer to data.json
- Added chu ko nu, steppe lancer, and plumed archer to villagers-required.js.
- Removed villager creation bonus from the Persian civ during dark age.

NOTES:
The math involved to calculate Plumed Archer cost is actually -1 for both food and wood... strange? Altered bonus to be 19% instead

Noticed that units like Plumed Archer and Chu Ko Nu does not include `wheelbarrow` when providing villagers required. Couldn't figure that out. Steppe Lancer was fine.

Also, how do we plan on handling units like Chu Ko Nu & Kipchak that fire multiple arrows?