### PR TITLE
Allow resource-num's width to expand for 3+ digits

### DIFF
--- a/src/css/villagers-required.css
+++ b/src/css/villagers-required.css
@@ -177,7 +177,7 @@
     cursor: pointer;
 }
 .resource-num div{
-    width: 40px;
+    min-width: 40px;
     border: 1px solid black;
     border-radius: 20px;
     text-align: center;


### PR DESCRIPTION
Allow resource-num's width to expand so that 3 digit numbers don't overflow their background.